### PR TITLE
Don't search node_modules folder on linting.

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -54,7 +54,7 @@ function ifTaskName(tasks) {
 gulp.task('default', function (done) {
   runSequence(['sass', 'browserify'], 'serve', function () {
     gulp.watch('./app/**/*.scss', ['sass']);
-    gulp.watch(['./**/*.+(js|jsx)', '!./node_modules/**', '!./.tmp/**'], ['lint']);
+    gulp.watch(['./*.js', './app/**/*.+(js|jsx)'], ['lint']);
     done();
   });
 });
@@ -107,7 +107,7 @@ gulp.task('serve:dist', ['build'], function () {
 });
 
 gulp.task('lint', function () {
-  return gulp.src(['./**/*.+(js|jsx)', '!./node_modules/**', '!./dist/**'])
+  return gulp.src(['./*.js', './app/**/*.+(js|jsx)'])
     .pipe($.react({errLogToConsole: true}))
     .pipe($.jshint('.jshintrc'))
     .pipe($.jshint.reporter('jshint-stylish'))


### PR DESCRIPTION
It seems having '!./node_modules/**' in gulp.src() doesn't actually prevent
node_modules from being traversed (it's files are just not passed on in the stream),
making linting very slow.
